### PR TITLE
feat: add request validation middleware and location endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "pino": "^9.9.5",
         "pino-http": "^10.5.0",
         "redis": "^5.8.2",
-        "validator": "^13.9.0"
+        "validator": "^13.9.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "jest": "^30.1.3",
@@ -6583,6 +6584,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "pino": "^9.9.5",
     "pino-http": "^10.5.0",
     "redis": "^5.8.2",
-    "validator": "^13.9.0"
+    "validator": "^13.9.0",
+    "zod": "^3.25.76"
   },
   "keywords": [
     "eesystem",

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ const helmet = require('helmet');
 const cors = require('cors');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
+const { validate, schemas } = require('./lib/validate');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -55,7 +56,69 @@ try {
 }
 
 app.get('/status', (req, res) => {
-  res.json({ ok: true, runtime });
+  res.json({ ok: true, data: runtime, meta: null });
+});
+
+function formatLocation(location) {
+  return {
+    id: location.id,
+    name: location.name,
+    address: location.address,
+    bookingUrl: location.bookingUrl,
+    googleMapsLink: location.googleMapsLink,
+    latitude: parseFloat(location.latitude),
+    longitude: parseFloat(location.longitude),
+    country: location.country
+  };
+}
+
+function calculateDistance(lat1, lng1, lat2, lng2) {
+  const R = 3959;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLng = (lng2 - lng1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+    Math.sin(dLng / 2) * Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+app.get('/api/locations/search', validate(schemas.search), (req, res) => {
+  const { q, limit } = req.validated;
+  const query = q.toLowerCase();
+  const locations = (store?.locations || [])
+    .filter(loc => {
+      const name = (loc.name || '').toLowerCase();
+      const address = (loc.address || '').toLowerCase();
+      const country = (loc.country || '').toLowerCase();
+      return name.includes(query) || address.includes(query) || country.includes(query);
+    })
+    .slice(0, limit)
+    .map(formatLocation);
+  res.json({ ok: true, data: locations, meta: { total: locations.length, query: q } });
+});
+
+app.get('/api/locations/nearest', validate(schemas.nearest), (req, res) => {
+  const { lat, lng, limit } = req.validated;
+  const results = (store?.locations || [])
+    .filter(loc => loc.latitude && loc.longitude)
+    .map(loc => {
+      const distance = calculateDistance(lat, lng, parseFloat(loc.latitude), parseFloat(loc.longitude));
+      return { ...formatLocation(loc), distance };
+    })
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit);
+  res.json({ ok: true, data: results, meta: { total: results.length, userLocation: { lat, lng } } });
+});
+
+app.get('/api/locations/by-location', validate(schemas.byLocation), (req, res) => {
+  const { country, city } = req.validated;
+  let results = (store?.locations || []).filter(loc => (loc.country || '').toLowerCase() === country.toLowerCase());
+  if (city) {
+    results = results.filter(loc => (loc.address || '').toLowerCase().includes(city.toLowerCase()));
+  }
+  results = results.map(formatLocation);
+  res.json({ ok: true, data: results, meta: { total: results.length, filters: { country, city } } });
 });
 
 if (enableAdmin) {

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -1,0 +1,36 @@
+const { z } = require('zod');
+
+const schemas = {
+  search: z.object({
+    q: z.string().trim().min(1),
+    limit: z.coerce.number().int().positive().max(100).default(10).optional()
+  }),
+  nearest: z.object({
+    lat: z.coerce.number().refine(n => Number.isFinite(n), 'Invalid latitude'),
+    lng: z.coerce.number().refine(n => Number.isFinite(n), 'Invalid longitude'),
+    limit: z.coerce.number().int().positive().max(100).default(5).optional()
+  }),
+  byLocation: z.object({
+    country: z.string().trim().min(1),
+    city: z.string().trim().min(1).optional()
+  })
+};
+
+function validate(schema) {
+  return (req, res, next) => {
+    const result = schema.safeParse(req.query);
+    if (!result.success) {
+      return res.status(400).json({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          details: result.error.flatten()
+        }
+      });
+    }
+    req.validated = result.data;
+    next();
+  };
+}
+
+module.exports = { validate, schemas };

--- a/tests/unit/locations.test.js
+++ b/tests/unit/locations.test.js
@@ -1,0 +1,49 @@
+const request = require('supertest');
+const app = require('../../src/app');
+
+describe('GET /api/locations/search', () => {
+  it('validates query params', async () => {
+    const res = await request(app).get('/api/locations/search');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns results', async () => {
+    const res = await request(app).get('/api/locations/search?q=tex');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body).toHaveProperty('meta');
+  });
+});
+
+describe('GET /api/locations/nearest', () => {
+  it('validates required params', async () => {
+    const res = await request(app).get('/api/locations/nearest');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns nearest locations', async () => {
+    const res = await request(app).get('/api/locations/nearest?lat=33.4554566&lng=-94.06533436&limit=1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data.length).toBeGreaterThan(0);
+  });
+});
+
+describe('GET /api/locations/by-location', () => {
+  it('requires country', async () => {
+    const res = await request(app).get('/api/locations/by-location');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('filters by country and city', async () => {
+    const res = await request(app).get('/api/locations/by-location?country=United%20States&city=Las%20Vegas');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Zod-based `validate` middleware with schemas for search, nearest, and by-location queries
- implement `/api/locations` endpoints using standardized `{ ok, data, meta }` responses
- cover validation and endpoint behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c53d6d16d083289b64f3778aca8a1e