### PR TITLE
feat: add geocode helper with redis cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The generated HTML includes:
 - Customize HTML template in the `generateOptimizedHTML` function
 - Adjust rate limiting and security settings as needed
 
+### Environment Variables
+
+- `NOMINATIM_UA` – User-Agent string (include contact email) for Nominatim requests
+- `NOMINATIM_EMAIL` – Contact email sent with Nominatim requests
+- `REDIS_URL` – Redis connection string for geocode caching (default `redis://localhost:6379`)
+
 ## 🔐 Admin Mode (Local Testing)
 
 The admin dashboards are disabled by default and not served in production. To enable them locally:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express-rate-limit": "^6.11.2",
         "helmet": "^8.1.0",
         "multer": "^1.4.5-lts.1",
+        "node-fetch": "^3.3.2",
         "openai": "^4.20.1",
         "pg": "^8.16.3",
         "pino": "^9.9.5",
@@ -2637,6 +2638,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3058,6 +3068,38 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3173,6 +3215,18 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -4682,23 +4736,21 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -4841,6 +4893,26 @@
           "optional": true
         },
         "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express-rate-limit": "^6.11.2",
     "helmet": "^8.1.0",
     "multer": "^1.4.5-lts.1",
+    "node-fetch": "^3.3.2",
     "openai": "^4.20.1",
     "pg": "^8.16.3",
     "pino": "^9.9.5",

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ const cors = require('cors');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 const { validate, schemas } = require('./lib/validate');
+const geocode = require('./core/geocode');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -19,13 +20,14 @@ app.use(pinoHttp({ logger }));
 app.use(helmet({ contentSecurityPolicy: false }));
 app.use(cors({ origin: ['https://eesystem.com', 'https://*.eesystem.com'] }));
 app.use(compression());
+app.use(express.json());
 
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: parseInt(process.env.RATE_LIMIT_MAX, 10) || 100
 });
 app.use('/search', limiter);
-app.use('/geocode', limiter);
+app.use('/api/locations/geocode', limiter);
 app.use('/upload', limiter);
 
 const runtime = {
@@ -119,6 +121,23 @@ app.get('/api/locations/by-location', validate(schemas.byLocation), (req, res) =
   }
   results = results.map(formatLocation);
   res.json({ ok: true, data: results, meta: { total: results.length, filters: { country, city } } });
+});
+
+app.post('/api/locations/geocode', async (req, res) => {
+  const { address } = req.body || {};
+  if (!address || !address.trim()) {
+    return res.status(400).json({ success: false, error: 'Address is required' });
+  }
+  try {
+    const coordinates = await geocode(address.trim());
+    if (!coordinates) {
+      return res.status(404).json({ success: false, error: 'Location not found' });
+    }
+    res.json({ success: true, query: address.trim(), coordinates });
+  } catch (err) {
+    logger.error('Geocoding failed', err);
+    res.status(500).json({ success: false, error: 'Failed to geocode address' });
+  }
 });
 
 if (enableAdmin) {

--- a/src/core/geocode.js
+++ b/src/core/geocode.js
@@ -1,0 +1,74 @@
+const crypto = require('crypto');
+const redis = require('redis');
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+const TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+let redisClient;
+async function getClient() {
+  if (redisClient) return redisClient;
+  try {
+    redisClient = redis.createClient({ url: REDIS_URL });
+    redisClient.on('error', (err) => {
+      console.warn('Redis error', err.message);
+    });
+    await redisClient.connect();
+  } catch (err) {
+    console.warn('Redis connection failed', err.message);
+    redisClient = null;
+  }
+  return redisClient;
+}
+
+async function geocode(address) {
+  const hash = crypto.createHash('sha1').update(address.toLowerCase()).digest('hex');
+  const cacheKey = `GEOCODE:addr:${hash}`;
+
+  try {
+    const client = await getClient();
+    if (client) {
+      const cached = await client.get(cacheKey);
+      if (cached) return JSON.parse(cached);
+    }
+
+    const headers = {};
+    if (process.env.NOMINATIM_UA) headers['User-Agent'] = process.env.NOMINATIM_UA;
+    if (process.env.NOMINATIM_EMAIL) headers['email'] = process.env.NOMINATIM_EMAIL;
+
+    const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(address)}`;
+    let attempt = 0;
+    let lastErr;
+    while (attempt < 3) {
+      try {
+        const res = await fetch(url, { headers });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const result = data[0];
+        if (!result) return null;
+        const coordinates = {
+          lat: parseFloat(result.lat),
+          lng: parseFloat(result.lon),
+          city: result.address?.city || result.address?.town || result.address?.village,
+          country: result.address?.country,
+          display_name: result.display_name
+        };
+        if (client) {
+          await client.set(cacheKey, JSON.stringify(coordinates), { EX: TTL_SECONDS });
+        }
+        return coordinates;
+      } catch (err) {
+        lastErr = err;
+        attempt += 1;
+        if (attempt >= 3) break;
+        const delay = 500 * Math.pow(2, attempt - 1);
+        await new Promise(r => setTimeout(r, delay));
+      }
+    }
+    throw lastErr;
+  } catch (err) {
+    throw err;
+  }
+}
+
+module.exports = geocode;


### PR DESCRIPTION
## Summary
- add geocoding helper with Nominatim fetch, Redis caching, and retry logic
- expose /api/locations/geocode route using helper and JSON body parsing
- document Nominatim and Redis environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c53ea213848328a45bbdccabdf2146