### PR TITLE
refactor: use haversine utility for distance

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ const cors = require('cors');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 const { validate, schemas } = require('./lib/validate');
+const haversine = require('./lib/haversine');
 const geocode = require('./core/geocode');
 
 const app = express();
@@ -74,17 +75,6 @@ function formatLocation(location) {
   };
 }
 
-function calculateDistance(lat1, lng1, lat2, lng2) {
-  const R = 3959;
-  const dLat = (lat2 - lat1) * Math.PI / 180;
-  const dLng = (lng2 - lng1) * Math.PI / 180;
-  const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
-    Math.sin(dLng / 2) * Math.sin(dLng / 2);
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return R * c;
-}
-
 app.get('/api/locations/search', validate(schemas.search), (req, res) => {
   const { q, limit } = req.validated;
   const query = q.toLowerCase();
@@ -105,7 +95,7 @@ app.get('/api/locations/nearest', validate(schemas.nearest), (req, res) => {
   const results = (store?.locations || [])
     .filter(loc => loc.latitude && loc.longitude)
     .map(loc => {
-      const distance = calculateDistance(lat, lng, parseFloat(loc.latitude), parseFloat(loc.longitude));
+      const distance = haversine(lat, lng, parseFloat(loc.latitude), parseFloat(loc.longitude));
       return { ...formatLocation(loc), distance };
     })
     .sort((a, b) => a.distance - b.distance)

--- a/src/lib/haversine.js
+++ b/src/lib/haversine.js
@@ -1,0 +1,13 @@
+function haversine(lat1, lon1, lat2, lon2) {
+  const R = 3959; // Radius of Earth in miles
+  const toRad = deg => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+module.exports = haversine;

--- a/tests/unit/haversine.test.js
+++ b/tests/unit/haversine.test.js
@@ -1,0 +1,12 @@
+const haversine = require('../../src/lib/haversine');
+
+describe('haversine', () => {
+  it('calculates distance between Los Angeles and New York', () => {
+    const distance = haversine(34.0522, -118.2437, 40.7128, -74.0060);
+    expect(distance).toBeCloseTo(2445.7, 1);
+  });
+
+  it('returns zero for identical coordinates', () => {
+    expect(haversine(0, 0, 0, 0)).toBeCloseTo(0, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared `haversine` distance function
- use `haversine` when determining nearest locations
- verify accuracy of distance math with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c53fb44d9c832899af115c79b8d076