### PR TITLE
test: add config env validation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "dev": "node src/app.js",
     "claude": "claude",
     "test": "npm run test:unit && npm run test:smoke && npm run test:e2e",
-    "test:unit": "NODE_ENV=test jest tests/unit --runInBand",
-    "test:smoke": "NODE_ENV=test jest tests/smoke --runInBand",
-    "test:e2e": "NODE_ENV=test jest tests/e2e --runInBand"
+    "test:unit": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/unit --runInBand",
+    "test:smoke": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/smoke --runInBand",
+    "test:e2e": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/e2e --runInBand"
   },
   "dependencies": {
     "@anthropic-ai/claude-code": "^1.0.105",

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1,0 +1,82 @@
+const { ZodError } = require('zod');
+
+const loadConfig = () => {
+  jest.resetModules();
+  return require('../../src/config');
+};
+
+describe('config', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('uses defaults when env vars are absent', () => {
+    delete process.env.PORT;
+    delete process.env.NODE_ENV;
+    delete process.env.RATE_LIMIT_MAX;
+    delete process.env.DATA_STORE;
+    delete process.env.MODE;
+    delete process.env.GEOCODER;
+    delete process.env.ENABLE_ADMIN;
+    delete process.env.ADMIN_TOKEN;
+    delete process.env.USE_LOCAL_DB;
+    delete process.env.REDIS_URL;
+    delete process.env.NOMINATIM_UA;
+    delete process.env.NOMINATIM_EMAIL;
+    delete process.env.DATABASE_URL;
+
+    const config = loadConfig();
+
+    expect(config.PORT).toBe(3000);
+    expect(config.NODE_ENV).toBe('development');
+    expect(config.RATE_LIMIT_MAX).toBe(100);
+    expect(config.DATA_STORE).toBe('json');
+    expect(config.MODE).toBe('basic');
+    expect(config.GEOCODER).toBe('nominatim');
+    expect(config.ENABLE_ADMIN).toBe(false);
+    expect(config.USE_LOCAL_DB).toBe(false);
+    expect(config.ADMIN_TOKEN).toBeUndefined();
+    expect(config.REDIS_URL).toBeUndefined();
+  });
+
+  it('coerces numeric and boolean env vars', () => {
+    process.env.PORT = '4000';
+    process.env.RATE_LIMIT_MAX = '200';
+    process.env.ENABLE_ADMIN = 'true';
+    process.env.USE_LOCAL_DB = 'true';
+
+    const config = loadConfig();
+
+    expect(config.PORT).toBe(4000);
+    expect(config.RATE_LIMIT_MAX).toBe(200);
+    expect(config.ENABLE_ADMIN).toBe(true);
+    expect(config.USE_LOCAL_DB).toBe(true);
+  });
+
+  it('supports optional variables when provided', () => {
+    process.env.ADMIN_TOKEN = 'secret';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+
+    const config = loadConfig();
+
+    expect(config.ADMIN_TOKEN).toBe('secret');
+    expect(config.REDIS_URL).toBe('redis://localhost:6379');
+  });
+
+  it('throws when numeric env vars are invalid', () => {
+    process.env.PORT = 'not-a-number';
+
+    try {
+      loadConfig();
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err.name).toBe('ZodError');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for config parsing defaults, coercion, optional values and invalid inputs
- run jest with experimental vm modules to support ESM imports

## Testing
- `npm run test:unit -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c553a2575883288c0d37be600d406e