### PR TITLE
test: add admin route tests

### DIFF
--- a/tests/unit/admin.test.js
+++ b/tests/unit/admin.test.js
@@ -1,0 +1,44 @@
+const request = require('supertest');
+
+const ADMIN_TOKEN = 'test-token';
+
+let app;
+
+describe('admin routes', () => {
+  beforeAll(() => {
+    process.env.ENABLE_ADMIN = 'true';
+    process.env.ADMIN_TOKEN = ADMIN_TOKEN;
+    jest.resetModules();
+    app = require('../../src/app');
+  });
+
+  it('rejects unauthorized access', async () => {
+    const res = await request(app).get('/admin');
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('serves admin.html with valid query token', async () => {
+    const res = await request(app).get('/admin').query({ token: ADMIN_TOKEN });
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toContain('EESystem Admin Testing Dashboard');
+  });
+
+  it('serves ai-interface.html with valid header token', async () => {
+    const res = await request(app)
+      .get('/ai-interface')
+      .set('x-admin-token', ADMIN_TOKEN);
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toContain('AI-Powered EESystem Location Manager');
+  });
+});
+
+describe('admin config', () => {
+  it('loads when ADMIN_TOKEN is missing', () => {
+    delete process.env.ADMIN_TOKEN;
+    process.env.ENABLE_ADMIN = 'true';
+    jest.resetModules();
+    require('../../src/app');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for admin interface routes, covering authorized and unauthorized access

## Testing
- `npm run test:unit -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c565a23f58832881b21bd4f431b598