### PR TITLE
Add rate limit tests for geocode and upload endpoints

### DIFF
--- a/tests/e2e/helpers/rateLimit.js
+++ b/tests/e2e/helpers/rateLimit.js
@@ -1,0 +1,21 @@
+const request = require('supertest');
+const app = require('../../../src/app');
+
+function makeRequest(method, endpoint, payload) {
+  let req = request(app)[method](endpoint);
+  if (payload) {
+    req = req.send(payload);
+  }
+  return req;
+}
+
+async function expectRateLimitExceeded(endpoint, { method = 'get', payload } = {}) {
+  const max = Number(process.env.RATE_LIMIT_MAX) || 2;
+  for (let i = 0; i < max; i++) {
+    await makeRequest(method, endpoint, payload);
+  }
+  const res = await makeRequest(method, endpoint, payload);
+  expect(res.status).toBe(429);
+}
+
+module.exports = { expectRateLimitExceeded };

--- a/tests/e2e/rate-limit.test.js
+++ b/tests/e2e/rate-limit.test.js
@@ -1,12 +1,20 @@
 process.env.RATE_LIMIT_MAX = 2;
-const request = require('supertest');
-const app = require('../../src/app');
+
+const { expectRateLimitExceeded } = require('./helpers/rateLimit');
 
 describe('E2E: rate limiting', () => {
-  it('returns 429 after exceeding limit', async () => {
-    await request(app).get('/search');
-    await request(app).get('/search');
-    const res = await request(app).get('/search');
-    expect(res.status).toBe(429);
+  it('limits /search requests', async () => {
+    await expectRateLimitExceeded('/search');
+  });
+
+  it('limits /api/locations/geocode requests', async () => {
+    await expectRateLimitExceeded('/api/locations/geocode', {
+      method: 'post',
+      payload: { address: '1600 Pennsylvania Ave' }
+    });
+  });
+
+  it('limits /upload requests', async () => {
+    await expectRateLimitExceeded('/upload', { method: 'post' });
   });
 });


### PR DESCRIPTION
## Summary
- expand rate limit e2e test coverage for geocode and upload routes
- refactor repeated request logic into reusable helper

## Testing
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68c56a85861083288eab956585561bfa