### PR TITLE
docs: document test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ npm run test:smoke
 npm run test:e2e
 ```
 
+### Testing & Coverage
+
+Run the full suite with coverage enabled:
+
+```bash
+npm test -- --coverage
+```
+
+This generates a coverage report in the `coverage/` directory. To explore the HTML report, open `coverage/lcov-report/index.html` in your browser. Lines marked in red indicate untested code, while summary tables show percentage coverage for statements, branches, functions, and lines.
+
 ## 📚 API Reference
 
 See [API_REFERENCE.md](docs/API_REFERENCE.md) for endpoint details and admin mode guidance.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node src/app.js",
     "dev": "node src/app.js",
     "claude": "claude",
-    "test": "npm run test:unit && npm run test:smoke && npm run test:e2e",
+    "test": "npm run test:unit -- --coverage=$npm_config_coverage && npm run test:smoke -- --coverage=$npm_config_coverage && npm run test:e2e -- --coverage=$npm_config_coverage",
     "test:unit": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/unit --runInBand",
     "test:smoke": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/smoke --runInBand",
     "test:e2e": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/e2e --runInBand"
@@ -43,5 +43,15 @@
   "devDependencies": {
     "jest": "^30.1.3",
     "supertest": "^7.1.4"
+  },
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- document how to run tests with coverage and interpret reports
- enforce 100% coverage via Jest config

## Testing
- `npm test -- --coverage` *(fails: global coverage threshold for statements (100%) not met: 35.5%)*

------
https://chatgpt.com/codex/tasks/task_e_68c585b4cbd88328b82234bcb5d3a721